### PR TITLE
fix: corrigir status de manutenções vencidas no kanban

### DIFF
--- a/src/api/company/categories/maintenance/controllers/getMaintenancesKanban.ts
+++ b/src/api/company/categories/maintenance/controllers/getMaintenancesKanban.ts
@@ -98,7 +98,7 @@ async function optimizedSyndicSeparePerStatus({ data }: { data: any }) {
             buildingName: maintenance.Building.name,
             element: maintenance.Maintenance.element,
             activity: maintenance.Maintenance.activity,
-            status: maintenance.MaintenancesStatus.name,
+            status: auxiliaryData < 0 ? 'expired' : maintenance.MaintenancesStatus.name, // Alterar status para 'expired' se vencida
             priorityLabel: maintenance.priority?.label,
             priorityColor: maintenance.priority?.color,
             priorityBackgroundColor: maintenance.priority?.backgroundColor,


### PR DESCRIPTION
- Manutenções 'pending' vencidas agora são classificadas como 'Vencidas' no kanban
- Status alterado para 'expired' quando manutenção está vencida (auxiliaryData < 0)
- Adicionar label 'Atrasada há X dias' para manutenções vencidas
- Manter lógica de ordenação existente (vencidas: mais antigas primeiro, pendentes: mais próximas primeiro)