### PR TITLE
fix: use maintenance frequency as tolerance period for cantReportExpired

### DIFF
--- a/src/api/company/categories/maintenance/controllers/getMaintenancesKanban.ts
+++ b/src/api/company/categories/maintenance/controllers/getMaintenancesKanban.ts
@@ -123,8 +123,9 @@ async function optimizedSyndicSeparePerStatus({ data }: { data: any }) {
           (today.getTime() - maintenance.dueDate.getTime()) / (1000 * 60 * 60 * 24),
         );
 
-        // Define tolerance period (e.g., 7 days after due date)
-        const tolerancePeriod = 7; // days
+        // Define tolerance period based on maintenance periodicity
+        const period = maintenance.Maintenance.frequency * maintenance.Maintenance.FrequencyTimeInterval.unitTime;
+        const tolerancePeriod = period; // Use maintenance periodicity as tolerance period
         const expirationDate = new Date(maintenance.dueDate);
         expirationDate.setDate(expirationDate.getDate() + tolerancePeriod);
 


### PR DESCRIPTION
- Replace fixed 7-day tolerance period with dynamic period based on maintenance frequency
- Use maintenance.frequency * maintenance.FrequencyTimeInterval.unitTime for tolerance calculation
- Ensures tolerance period matches the actual maintenance schedule (monthly, weekly, etc.)